### PR TITLE
Configure the lcrt config folder path

### DIFF
--- a/src/foperate.c
+++ b/src/foperate.c
@@ -290,3 +290,33 @@ int lcrt_echeck(const char *prog, char *p_path)
     return rv;
 }
 
+/**
+ * @brief loads the first non-empty  line from a file, trimmed from its terminating linefeed character
+ * @param filepath the path for the file to load and read
+ * @param buffer the char buffer where to store the content, untouched if the file does not exist
+ * @param buflen the buffer size, if the line found is bigger than this, it ends up truncated
+ * @return = 0, if a non-empty line was found and stored in the buffer
+ *         < 0, error code, -2 if the file was not found, -1 if no non-empty line was found in the file
+ */
+int lcrt_floadline(char *filepath, char *buffer, int buflen) {
+  FILE *fp;
+  char tmpbuf[256];
+  int len;
+  int rv = -2;
+  if ((fp = fopen(filepath, "r")) != NULL) {
+    rv = -1;
+    while (fgets(tmpbuf, sizeof(tmpbuf), fp)) {
+      len = strlen(tmpbuf);
+      if (len>0 && tmpbuf[len-1] == '\n') {
+	tmpbuf[len-1]=0;
+      }
+      if (strlen(tmpbuf)>0) {
+	strncpy(buffer, tmpbuf, buflen);
+	rv = 0;
+	break;
+      }
+    }
+    fclose(fp);
+  }
+  return rv;
+}

--- a/src/foperate.h
+++ b/src/foperate.h
@@ -86,4 +86,13 @@ int lcrt_fcreate(const char *fname);
  */
 int lcrt_echeck(const char *prog, char *p_path);
 
+/**
+ * @brief loads the first non-empty  line from a file, trimmed from its terminating linefeed character
+ * @param filepath the path for the file to load and read
+ * @param buffer the char buffer where to store the content, untouched if the file does not exist
+ * @param buflen the buffer size, if the line found is bigger than this, it ends up truncated
+ * @return = 0, if a non-empty line was found and stored in the buffer
+ *         < 0, error code, -2 if the file was not found, -1 if no non-empty line was found in the file
+ */
+int lcrt_floadline(char *filepath, char *buffer, int buflen);
 #endif

--- a/src/mkconfig.c
+++ b/src/mkconfig.c
@@ -205,10 +205,22 @@ int lcrt_config_save_language(char *language_name)
 int lcrt_config_load()
 {
     char *home;
+    char redir_content[256];
+
     if ((home = getenv("HOME")) == NULL) {
-        home = ".";
+      home = ".";
     }
-    snprintf(local_config_dir, sizeof(local_config_dir), "%s/.lcrt", home);
+    
+    /* If there's a .lcrt_redirect file, we use its content as home path to find the lcrt config folder */
+    snprintf(local_config_dir, sizeof(local_config_dir), "%s/.lcrt_redirect", home);
+
+    if (lcrt_floadline(local_config_dir, redir_content, sizeof(redir_content)) == 0) {
+      strncpy(local_config_dir, redir_content, sizeof(redir_content)<sizeof(local_config_dir)?sizeof(redir_content):sizeof(local_config_dir));
+    } else {
+      /* If there's no $HOME/.lcrt_redirect, the default is $HOME/.lcrt/ */
+      snprintf(local_config_dir, sizeof(local_config_dir), "%s/.lcrt", home);
+    }
+
     lcrt_fmkdir(local_config_dir);
     lcrt_config_load_language();
     return 0;


### PR DESCRIPTION
As I needed to be able to have lcrt store its config folder on a shared directory that replicates on a server, I added support for an optional $HOME/.lcrt_redirect file.

If this file exists, its first non-empty line is used as path for the lcrt config folder, otherwise the default behavior (using $HOME/.lcrt) is used.

For instance, say the $HOME/.lcrt_redirect contains the line "/opt/shared/lcrt", then the config is stored directly under /opt/shared/lcrt (ie. NOT /opt/shared/lcrt/.lcrt).
